### PR TITLE
Add WhatFont extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ If you want to add some tools that you actually use, please do it! PR's are open
 - Extension 🎯 - [VisBug](https://chrome.google.com/webstore/detail/visbug/cdockenadnadldjbbgcallicgledbeoc)
 
   _Design debug tools_
-  
-- Extension 🎯 - [Wappalyzer](https://chrome.google.com/webstore/detail/wappalyzer/gppongmhjkpfnbhagpmjfkannfbllamg?hl=es)
-
+ 
 - Extension 🎯 - [Wappalyzer](https://chrome.google.com/webstore/detail/wappalyzer/gppongmhjkpfnbhagpmjfkannfbllamg?hl=es)
 
   _A browser extension that uncovers the technologies used on websites._

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ If you want to add some tools that you actually use, please do it! PR's are open
 - Extension 🎯 - [JSON Viewer Awesome](https://chrome.google.com/webstore/detail/json-viewer-awesome/iemadiahhbebdklepanmkjenfdebfpfe)
 
   _A browser extension for visualize formatted JSON responses from APIs_
+  
+- Extension 🎯 - [WhatFont](https://chrome.google.com/webstore/detail/whatfont/jabopobgcpjmedljpbcaablpmlmfcogm?hl=Es)
+
+  _The easiest way to identify fonts on web pages._
 
 ## CSS
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ If you want to add some tools that you actually use, please do it! PR's are open
 - Extension 🎯 - [VisBug](https://chrome.google.com/webstore/detail/visbug/cdockenadnadldjbbgcallicgledbeoc)
 
   _Design debug tools_
+  
+- Extension 🎯 - [Wappalyzer](https://chrome.google.com/webstore/detail/wappalyzer/gppongmhjkpfnbhagpmjfkannfbllamg?hl=es)
+
+  _A browser extension that uncovers the technologies used on websites._
 
 ## CSS
 
@@ -48,3 +52,7 @@ If you want to add some tools that you actually use, please do it! PR's are open
 - Web 🌏 - [unsplash.com](https://unsplash.com/)
 
   _High quality photos free of copyright_
+  
+- Web 🌏 - [coolors.co](https://coolors.co/app)
+
+  _A super fast color schemes generator!_


### PR DESCRIPTION
Add [WhatFont](https://chrome.google.com/webstore/detail/whatfont/jabopobgcpjmedljpbcaablpmlmfcogm?hl=Es) extension. The easiest way to identify fonts on web pages.